### PR TITLE
`make` then `_rel/lsl/bin/lsl console` Does not work now.

### DIFF
--- a/src/lsl.app.src
+++ b/src/lsl.app.src
@@ -9,7 +9,8 @@
     sasl,
     lager,
     cowboy,
-    sumo_db,
+    sumo_rest,
+    mnesia,
     erlpass
   ]},
   {modules, []},


### PR DESCRIPTION
Steps to reproduce:

Just these two commands:

```
make
_rel/lsl/bin/lsl console
```

1.
Firstly, make doesn't work because somehow it cannot connect to S3/AWS (I didn't copy the error message and it scrolled off the screen.)

It happens when getting the deps of dep `katana`.
- I fixed that by changing the Makefile dep `katana` to the same one as `inaka/canillita` project's (because that worked for me earlier; if I remember correctly or else I think I manually set the dep repo to github https in place of lsl's original hex {version no.}) and got everything to `make` successfully. 

2.
Next `... lsl console` hit into an error because the lsl.app.src file is wrong.

Firstly, it doesn't include mnesia, which causes sumo_db application startup to fail.
Next, it didn't start trails, so I changed sumo_db to sumo_rest

Here is the app.src file section that finally worked for me:

```
...
  {applications, [
    kernel,
    stdlib,

    mnesia,

    sasl,
    lager,
    cowboy,

    sumo_rest,
    %sumo_db,

    erlpass
  ]},
...
```

I am a newbie in Erlang.

But so far all this while I tried many sample projects from GitHub, many of them (8 out of 10 times) (even the currently committed ones) can never build and just work 'out of the box'.

Q. Is it a common thing that I should always expect and need to get used to when trying to get into Erlang projects?

Warm Regards,
Bill.
